### PR TITLE
Persist config, allow exclude/include switch

### DIFF
--- a/api/module.php
+++ b/api/module.php
@@ -24,6 +24,12 @@ class PMKID extends Module
             case 'getInterfaces':
                 $this->getInterfaces();
                 break;
+            case 'updateConfig':
+                $this->updateConfig();
+                break;
+            case 'getConfig':
+                $this->getConfig();
+                break;
             case 'getAPs':
                 $this->getAPs();
                 break;
@@ -199,6 +205,22 @@ class PMKID extends Module
         );
     }
 
+    private function updateConfig()
+    {
+      exec("uci set pmkid.module.commandLineArguments='{$this->request->commandLineArguments}'");
+      exec("uci commit pmkid.module.commandLineArguments");
+      exec("uci set pmkid.module.includeOrExclude='{$this->request->includeOrExclude}'");
+      exec("uci commit pmkid.module.includeOrExclude");
+    }
+
+    private function getConfig()
+    {
+      $this->response = array(
+        "commandLineArguments" => $this->uciGet("pmkid.module.commandLineArguments"),
+        "includeOrExclude" => $this->uciGet("pmkid.module.includeOrExclude")
+      );
+    }
+
     private function getAPs()
     {
         if (!$this->request->skipScan) exec("/pineapple/modules/PMKID/scripts/scan.sh {$this->request->interface} {$this->request->duration}");
@@ -219,7 +241,7 @@ class PMKID extends Module
           fwrite($fp, implode("\n", $this->request->selectedAps));
           fclose($fp);
         }
-        exec("/pineapple/modules/PMKID/scripts/capture.sh start {$this->request->interface} {$this->request->commandLineArguments}");
+        exec("/pineapple/modules/PMKID/scripts/capture.sh start {$this->request->interface} {$this->request->includeOrExclude} {$this->request->commandLineArguments}");
     }
 
 		private function stopCapture()

--- a/js/module.js
+++ b/js/module.js
@@ -108,6 +108,25 @@ registerController('PMKID_ScanController', ['$api', '$scope', '$rootScope', '$ti
     $scope.capturing ? $scope.stopCapture() : $scope.startCapture();
   });
 
+  $scope.updateConfig = (function() {
+    $api.request({
+      module: 'PMKID',
+      action: 'updateConfig',
+      commandLineArguments: $scope.commandLineArguments,
+      includeOrExclude: $scope.includeOrExclude
+    })
+  });
+
+  $scope.getConfig = (function() {
+    $api.request({
+      module: 'PMKID',
+      action: 'getConfig'
+    }, function (response) {
+      $scope.commandLineArguments = response.commandLineArguments
+      $scope.includeOrExclude = response.includeOrExclude
+    })
+  })
+
   $scope.startCapture = (function() {
     $scope.captureLabel = "warning";
     $scope.captureText = "Starting...";
@@ -118,6 +137,7 @@ registerController('PMKID_ScanController', ['$api', '$scope', '$rootScope', '$ti
       module: 'PMKID',
       action: 'startCapture',
       interface: $scope.selectedInterface,
+      includeOrExclude: $scope.includeOrExclude,
       commandLineArguments: $scope.commandLineArguments,
       selectedAps
     }, function(response) {
@@ -233,6 +253,7 @@ registerController('PMKID_ScanController', ['$api', '$scope', '$rootScope', '$ti
   $scope.output = 'Loading...';
   $scope.pmkids = [];
 
+  $scope.getConfig();
   $scope.getInterfaces();
   $scope.getScanStatus();
   $scope.refreshOutput();

--- a/module.html
+++ b/module.html
@@ -73,7 +73,7 @@
           </select>
 
           <span class="input-group-addon input-sm">Command Line Arguments</span>
-          <input type="text" class="form-control input-sm" ng-disabled="captureStarting || captureStopping || capturing" ng-model="commandLineArguments"/>
+          <input type="text" class="form-control input-sm" ng-disabled="captureStarting || captureStopping || capturing" ng-model="commandLineArguments" ng-change="updateConfig()"/>
 
           <span class="input-group-btn">
             <button class="btn btn-{{scanLabel}} btn-sm" ng-disabled="scanning || captureStarting || captureStopping || capturing" ng-click="getAPs()">{{ scanText }}</button>
@@ -101,7 +101,12 @@
     <table class="table">
       <thead>
         <tr>
-          <th>Include</th>
+          <th>
+            <select class="form-control" ng-model="includeOrExclude" ng-change="updateConfig()">
+              <option value="include" selected>Include</option>
+              <option value="exclude">Exclude</option>
+            </select>
+          </th>
           <th>MAC</th>
           <th>BSSID</th>
           <th>POWNED</th>

--- a/module.info
+++ b/module.info
@@ -6,5 +6,5 @@
         "tetra"
     ],
     "title": "PMKID",
-    "version": "0.2"
+    "version": "0.3"
 }

--- a/scripts/capture.sh
+++ b/scripts/capture.sh
@@ -10,7 +10,19 @@ LOCK=/tmp/pmkid.lock
 
 MYMONITOR=''
 MYINTERFACE=$2
-COMMANDLINEARGS=${*:3}
+INCLUDEOREXCLUDE=$3
+case "$INCLUDEOREXCLUDE" in
+  include)
+    FILTERMODE=2
+    ;;
+  exclude)
+    FILTERMODE=1
+    ;;
+  *)
+    FILTERMODE=2
+    ;;
+esac
+COMMANDLINEARGS=${*:4}
 
 if [ "$1" = "start" ]; then
 
@@ -56,7 +68,7 @@ if [ "$1" = "start" ]; then
 
   echo $MYTIME > ${LOCK}
 
-  hcxdumptool -o /pineapple/modules/PMKID/capture/capture_${MYTIME} -i ${MYMONITOR} $COMMANDLINEARGS --filtermode=2 --filterlist=/tmp/pmkid-selectedAps &> ${LOG} &
+  hcxdumptool -o /pineapple/modules/PMKID/capture/capture_${MYTIME} -i ${MYMONITOR} $COMMANDLINEARGS --filtermode=$FILTERMODE --filterlist=/tmp/pmkid-selectedAps &> ${LOG} &
 
 elif [ "$1" = "stop" ]; then
   killall -9 hcxdumptool

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -26,6 +26,10 @@ if [ "$1" = "install" ]; then
   touch /etc/config/pmkid
   echo "config pmkid 'module'" > /etc/config/pmkid
 
+  uci set pmkid.module.commandLineArguments='--enable_status 3'
+  uci commit pmkid.module.commandLineArguments
+  uci set pmkid.module.includeOrExclude='include'
+  uci commit pmkid.module.includeOrExclude
   uci set pmkid.module.installed=1
   uci commit pmkid.module.installed
 


### PR DESCRIPTION
This release adds a few new features as requested by the community.

* Changes to config (specifically the command line args) are now persisted
* The ability to switch between include and exclude as the filter mode is provided
