### PR TITLE
Fixed dependencies script not working due to changes in the repositor…

### DIFF
--- a/scripts/capture.sh
+++ b/scripts/capture.sh
@@ -68,7 +68,7 @@ if [ "$1" = "start" ]; then
 
   echo $MYTIME > ${LOCK}
 
-  hcxdumptool -o /pineapple/modules/PMKID/capture/capture_${MYTIME} -i ${MYMONITOR} $COMMANDLINEARGS --filtermode=$FILTERMODE --filterlist=/tmp/pmkid-selectedAps &> ${LOG} &
+  hcxdumptool -o /pineapple/modules/PMKID/capture/capture_${MYTIME} -i ${MYMONITOR} $COMMANDLINEARGS --filtermode=$FILTERMODE --filterlist_ap=/tmp/pmkid-selectedAps &> ${LOG} &
 
 elif [ "$1" = "stop" ]; then
   killall -9 hcxdumptool

--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -8,18 +8,18 @@ export PATH=$PATH:/sd/usr/bin:/sd/usr/sbin
 
 touch /tmp/PMKID.progress
 mkdir -p /tmp/PMKID
-wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/tree/master/bin/ar71xx/packages/base -P /tmp/PMKID
-HCXDUMPTOOL=`grep -F "hcxdumptool_" /tmp/PMKID/base | awk {'print $5'} | awk -F'"' {'print $2'}`
-HCXTOOLS=`grep -F "hcxtools_" /tmp/PMKID/base | awk {'print $5'} | awk -F'"' {'print $2'}`
+wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/tree/openwrt-19.07-mk6/bin/packages/mips_24kc/custom -P /tmp/PMKID
+HCXDUMPTOOL=`grep -F "hcxdumptool-custom_" /tmp/PMKID/custom | awk {'print $8'} | awk -F'"' {'print $2'}`
+HCXTOOLS=`grep -F "hcxtools-custom_" /tmp/PMKID/custom | awk {'print $8'} | awk -F'"' {'print $2'}`
 
 if [ "$1" = "install" ]; then
   if [ "$2" = "internal" ]; then
-    wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/raw/master/bin/ar71xx/packages/base/"$HCXDUMPTOOL" -P /tmp/PMKID
-    wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/raw/master/bin/ar71xx/packages/base/"$HCXTOOLS" -P /tmp/PMKID
+    wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/raw/openwrt-19.07-mk6/bin/packages/mips_24kc/custom/"$HCXDUMPTOOL" -P /tmp/PMKID
+    wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/raw/openwrt-19.07-mk6/bin/packages/mips_24kc/custom/"$HCXTOOLS" -P /tmp/PMKID
     opkg install /tmp/PMKID/*.ipk
   elif [ "$2" = "sd" ]; then
-    wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/raw/master/bin/ar71xx/packages/base/"$HCXDUMPTOOL" -P /tmp/PMKID
-    wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/raw/master/bin/ar71xx/packages/base/"$HCXTOOLS" -P /tmp/PMKID
+    wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/raw/openwrt-19.07-mk6/bin/packages/mips_24kc/custom/"$HCXDUMPTOOL" -P /tmp/PMKID
+    wget https://github.com/adde88/hcxtools-hcxdumptool-openwrt/raw/openwrt-19.07-mk6/bin/packages/mips_24kc/custom/"$HCXTOOLS" -P /tmp/PMKID
     opkg install /tmp/PMKID/*.ipk --dest sd
   fi
 


### PR DESCRIPTION
Fixes #5 
 - Updated dependencies script with new location of hcxdumptool and hcxtools.
- Updated capture script since hcxdumptool filter argument has changed.